### PR TITLE
Don't update the "active" index table from the "reindex" job

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -639,7 +639,7 @@
         ;; Ideally this would be DRY with the actual specification some way, but since this is a stop-gap solution, we
         ;; decided not to complicate the solution further to accomplish this.
         (search/bulk-ingest! (for [search-model ["card" "dataset" "metric"]]
-                               [search-model [:= :this.id id]])))
+                               [search-model [:= :this.id id]]) false))
       (when metadata-future
         (log/infof "Metadata not available soon enough. Saving card %s and asynchronously updating metadata" id)
         (card.metadata/save-metadata-async! metadata-future card))

--- a/src/metabase/search/core.clj
+++ b/src/metabase/search/core.clj
@@ -100,7 +100,7 @@
                             (remove (comp search.util/impossible-condition? second))
                             seq)]
       ;; We need to delay execution to handle deletes, which alert us *before* updating the database.
-      (search.ingestion/ingest-maybe-async! updates))))
+      (search.ingestion/ingest-maybe-async! updates false))))
 
 (defn delete!
   "Given a model and a list of model's ids, remove corresponding search entries."

--- a/src/metabase/search/engine.clj
+++ b/src/metabase/search/engine.clj
@@ -31,8 +31,8 @@
 
 (defmulti consume!
   "Updates the search index by consuming the documents from the given reducible."
-  {:arglists '([search-engine document-reducible])}
-  (fn [search-engine _document-reducible]
+  {:arglists '([search-engine document-reducible re-indexing?])}
+  (fn [search-engine _document-reducible _re-indexing?]
     search-engine))
 
 (defmulti delete!

--- a/src/metabase/search/ingestion.clj
+++ b/src/metabase/search/ingestion.clj
@@ -103,7 +103,7 @@
 (defn populate-index!
   "Go over all searchable items and populate the index with them."
   [engine]
-  (search.engine/consume! engine (query->documents (search-items-reducible))))
+  (search.engine/consume! engine (query->documents (search-items-reducible)) true))
 
 (def ^:dynamic *force-sync*
   "Force ingestion to happen immediately, on the same thread."
@@ -115,24 +115,24 @@
 
 (defn consume!
   "Update all active engines' indexes with the given documents"
-  [documents-reducible]
+  [documents-reducible re-indexing?]
   (when-let [engines (seq (search.engine/active-engines))]
     (if (= 1 (count engines))
-      (search.engine/consume! (first engines) documents-reducible)
+      (search.engine/consume! (first engines) documents-reducible re-indexing?)
       ;; TODO um, multiplexing over the reducible awkwardly feels strange. We at least use a magic number for now.
       (doseq [batch (eduction (partition-all 150) documents-reducible)
               e     engines]
-        (search.engine/consume! e batch)))))
+        (search.engine/consume! e batch re-indexing?)))))
 
 (defn bulk-ingest!
   "Process the given search model updates. Returns the number of search index entries that get updated as a result."
-  [updates]
+  [updates re-indexing?]
   (->> (for [[search-model where-clauses] (u/group-by first second updates)]
          (spec-index-reducible search-model (into [:or] (distinct where-clauses))))
        ;; init collection is only for clj-kondo, as we know that the list is non-empty
        (reduce u/rconcat [])
        query->documents
-       consume!))
+       (#(consume! % re-indexing?))))
 
 (defn- track-queue-size! []
   (analytics/set! :metabase-search/queue-size (.size queue)))
@@ -144,12 +144,12 @@
   "Update or create any search index entries related to the given updates.
   Will be async if the worker exists, otherwise it will be done synchronously on the calling thread.
   Can also be forced to run synchronously for testing."
-  ([updates]
-   (ingest-maybe-async! updates (or *force-sync* (not (index-worker-exists?)))))
-  ([updates sync?]
+  ([updates re-indexing?]
+   (ingest-maybe-async! updates (or *force-sync* (not (index-worker-exists?))) re-indexing?))
+  ([updates sync? re-indexing?]
    (when-not *disable-updates*
      (if sync?
-       (bulk-ingest! updates)
+       (bulk-ingest! updates re-indexing?)
        (do
          (doseq [update updates]
            (log/trace "Queuing update" update)

--- a/test/metabase/search/appdb/scoring_test.clj
+++ b/test/metabase/search/appdb/scoring_test.clj
@@ -198,7 +198,7 @@
                                                                   (card-with-view i))))
                 _               (search.ingestion/consume!
                                  (#'search.ingestion/query->documents
-                                  (#'search.ingestion/spec-index-reducible "card" [:= :this.name search-term])))
+                                  (#'search.ingestion/spec-index-reducible "card" [:= :this.name search-term])) false)
                 first-result-id (-> (search-results* search-term) first second)]
             (is (some? first-result-id))
            ;; Ideally we would make the outlier slightly less attractive in another way, with a weak weight,


### PR DESCRIPTION
### Description

When there are realtime updates to items, we update both the "active" index and the "pending" index still being created (if one exists). We need both as the re-indexing might still take some time, but it may also have already progressed past the corresponding entities.
### Checklist

    * [x]  Tests have been added/updated to cover changes in this PR

